### PR TITLE
fix: :fire: correct the typo

### DIFF
--- a/app/styles/DefaultModuleStyles.js
+++ b/app/styles/DefaultModuleStyles.js
@@ -1,13 +1,13 @@
 import { DefaultCoreStyles } from "@wrappid/core";
 
 export default class DefaultModuleStyles extends DefaultCoreStyles {
-  constructor(){
+  constructor() {
     super();
     this.style = {
       /**************************************************
        * Using defaultUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/LargeModuleStyles.js
+++ b/app/styles/LargeModuleStyles.js
@@ -1,13 +1,13 @@
 import { LargeCoreStyles } from "@wrappid/core";
 
 export default class LargeModuleStyles extends LargeCoreStyles {
-  constructor(){
+  constructor() {
     super();
     this.style = {
       /**************************************************
        * Using LargeUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/MediumModuleStyles.js
+++ b/app/styles/MediumModuleStyles.js
@@ -1,13 +1,13 @@
 import { MediumCoreStyles } from "@wrappid/core";
 
 export default class MediumModuleStyles extends MediumCoreStyles {
-  constructor(){
+  constructor() {
     super();
     this.style = {
       /**************************************************
        * Using defaultUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/SmallModuleStyles.js
+++ b/app/styles/SmallModuleStyles.js
@@ -1,13 +1,13 @@
 import { SmallCoreStyles } from "@wrappid/core";
 
 export default class SmallModuleStyles extends SmallCoreStyles {
-  constructor(){
+  constructor() {
     super();
     this.style = {
       /**************************************************
        * Using smallUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/XLargeModuleStyles.js
+++ b/app/styles/XLargeModuleStyles.js
@@ -1,13 +1,13 @@
 import { XLargeCoreStyles } from "@wrappid/core";
 
 export default class XLargeModuleStyles extends XLargeCoreStyles {
-  constructor(){
+  constructor() {
     super();
     this.style = {
       /**************************************************
        * Using XLargeUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/XXLargeModuleStyles.js
+++ b/app/styles/XXLargeModuleStyles.js
@@ -1,13 +1,13 @@
 import { XXLargeCoreStyles } from "@wrappid/core";
 
 export default class XXLargeModuleStyles extends XXLargeCoreStyles {
-  constructor(){
+  constructor() {
     super();
     this.style = {
       /**************************************************
        * Using XXLargeUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.styles.devBorder },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }


### PR DESCRIPTION
correct the typo in ModuleStyles file from 'styles' to style

ref: #17

## Description

Correct the typo
-app/styles/DefaultModuleStyles.js
-app/styles/LargeModuleStyles.js
-app/styles/MediumModuleStyles.js
-app/styles/SmallModuleStyles.js
-app/styles/XLargeModuleStyles.js
-app/styles/XXLargeModuleStyles.js
correct styles to style## Related Issues

<!--List any related issues that this pull request addresses. -->

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [ ] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [ ] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
