### PR TITLE
fix: remove 'Auth' style object from CoreClasses.js and it will be shifted to ModuleClasses.js of auth-module

### DIFF
--- a/app/styles/DefaultModuleStyles.js
+++ b/app/styles/DefaultModuleStyles.js
@@ -1,13 +1,33 @@
-import { DefaultCoreStyles } from "@wrappid/core";
+// eslint-disable-next-line import/no-unresolved
+import { DefaultUtilityStyles, IMPORTANT, BaseStyle } from "@wrappid/styles";
 
-export default class DefaultModuleStyles extends DefaultCoreStyles {
+export default class DefaultModuleStyles extends BaseStyle {
+  defaultUtilityStyles = new DefaultUtilityStyles().style;
   constructor() {
     super();
     this.style = {
       /**************************************************
        * Using defaultUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.style.devBorder },
+      testWrappidStyleClass: { ...this.defaultUtilityStyles.devBorder },
+
+      authAppLogo: {
+        height: 50,
+        width: 190
+      },
+
+      authCard: {
+        background: "transparent" + IMPORTANT,
+        boxShadow: "none" + IMPORTANT
+      },
+
+      authWrapper: {
+        ...this.defaultUtilityStyles.justifyContentCenter,
+        ...this.defaultUtilityStyles.alignContentCenter,
+        ...this.defaultUtilityStyles.flexWrapWrap,
+        ...this.defaultUtilityStyles.vh100,
+        width: "98vw" + IMPORTANT,
+      },
     };
   }
 }

--- a/app/styles/LargeModuleStyles.js
+++ b/app/styles/LargeModuleStyles.js
@@ -1,13 +1,26 @@
-import { LargeCoreStyles } from "@wrappid/core";
+// eslint-disable-next-line import/no-unresolved
+import { BaseStyle, IMPORTANT, LargeUtilityStyles } from "@wrappid/styles";
 
-export default class LargeModuleStyles extends LargeCoreStyles {
+export default class LargeModuleStyles extends BaseStyle {
+  largeUtilityStyles = new LargeUtilityStyles().style;
   constructor() {
     super();
     this.style = {
       /**************************************************
        * Using LargeUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.style.devBorder },
+      testWrappidStyleClass: { ...this.largeUtilityStyles.devBorder },
+      authBanner: {
+        backgroundImage: "url(./images/welcome-bg.png)",
+        backgroundPosition: "center" + IMPORTANT,
+        backgroundRepeat: "no-repeat" + IMPORTANT,
+        backgroundSize: "cover" + IMPORTANT,
+        height: "100%" + IMPORTANT,
+      },
+      authContainer: { height: "100%" + IMPORTANT },
+      authForm: { height: "100%" + IMPORTANT },
+      authFormContainer: { width: "60%" + IMPORTANT },
+      authWrapper: { width: "45vw" + IMPORTANT },
     };
   }
 }

--- a/app/styles/MediumModuleStyles.js
+++ b/app/styles/MediumModuleStyles.js
@@ -1,13 +1,36 @@
-import { MediumCoreStyles } from "@wrappid/core";
+import {
+  IMPORTANT,
+  BaseStyle,
+  MediumUtilityStyles
+  // eslint-disable-next-line import/no-unresolved
+} from "@wrappid/styles";
 
-export default class MediumModuleStyles extends MediumCoreStyles {
+export default class MediumModuleStyles extends BaseStyle {
+  mediumUtilityStyles = new MediumUtilityStyles().style;
   constructor() {
     super();
     this.style = {
       /**************************************************
        * Using defaultUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.style.devBorder },
+      testWrappidStyleClass: { ...this.mediumUtilityStyles.devBorder },
+      authBanner: {
+        backgroundImage: "url(./images/welcome-bg.png)" + IMPORTANT,
+        backgroundPosition: "center" + IMPORTANT,
+        backgroundRepeat: "no-repeat" + IMPORTANT,
+        backgroundSize: "cover" + IMPORTANT,
+        height: "100%" + IMPORTANT,
+      },
+
+      authCardMaxWidth: { maxWidth: "25%" + IMPORTANT },
+      authCardMinWidth: { minWidth: "25%" + IMPORTANT },
+      authContainer: { height: "100%" + IMPORTANT },
+
+      authForm: { height: "100%" + IMPORTANT },
+
+      authFormContainer: { width: "60%" + IMPORTANT },
+
+      authWrapper: { width: "45vw" + IMPORTANT },
     };
   }
 }

--- a/app/styles/ModuleClasses.js
+++ b/app/styles/ModuleClasses.js
@@ -9,7 +9,11 @@ const ModuleClasses = {
         CARD_MAX_WIDTH: "authCardMaxWidth",
         CARD_MIN_WIDTH: "authCardMinWidth",
         LOGO: "authAppLogo",
-        WRAPPER: "authWrapper"
+        WRAPPER: "authWrapper",
+        BANNER: "authBanner",
+        CONATINER: "authContainer",
+        FORM: "authForm",
+        FORMCONATINER: "authFormContainer"
     }
 };
 

--- a/app/styles/ModuleClasses.js
+++ b/app/styles/ModuleClasses.js
@@ -1,3 +1,16 @@
-const ModuleClasses = { TEST_WRAPPID_STYLE_CLASS: "testWrappidStyleClass" };
+// eslint-disable-next-line import/no-unresolved
+import { UtilityClasses } from "@wrappid/styles";
+
+const ModuleClasses = {
+    ...UtilityClasses,
+    TEST_WRAPPID_STYLE_CLASS: "testWrappidStyleClass",
+    AUTH: {
+        CARD: "authCard",
+        CARD_MAX_WIDTH: "authCardMaxWidth",
+        CARD_MIN_WIDTH: "authCardMinWidth",
+        LOGO: "authAppLogo",
+        WRAPPER: "authWrapper"
+    }
+};
 
 export default ModuleClasses;

--- a/app/styles/SmallModuleStyles.js
+++ b/app/styles/SmallModuleStyles.js
@@ -1,13 +1,39 @@
-import { SmallCoreStyles } from "@wrappid/core";
+import {
+  IMPORTANT,
+  SmallUtilityStyles,
+  BaseStyle
+  // eslint-disable-next-line import/no-unresolved
+} from "@wrappid/styles";
 
-export default class SmallModuleStyles extends SmallCoreStyles {
+export default class SmallModuleStyles extends BaseStyle {
+  smallUtilityStyles = new SmallUtilityStyles().style;
   constructor() {
     super();
     this.style = {
       /**************************************************
        * Using smallUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.style.devBorder },
+      testWrappidStyleClass: { ...this.smallUtilityStyles.devBorder },
+      authAppLogo: { width: 190 },
+
+      /**
+       * @todo review required 
+        authAppLogo: {
+          height: "auto",
+          width : 190
+        }, 
+      */
+      authBanner: {
+        backgroundImage: "url(./images/welcome-bg.png)" + IMPORTANT,
+        backgroundPosition: "center" + IMPORTANT,
+        backgroundRepeat: "no-repeat" + IMPORTANT,
+        backgroundSize: "cover" + IMPORTANT,
+        height: "100%" + IMPORTANT,
+      },
+
+      authContainer: { height: "100%" + IMPORTANT },
+      authForm: { height: "100%" + IMPORTANT },
+      authFormContainer: { width: "100%" + IMPORTANT },
     };
   }
 }

--- a/app/styles/XLargeModuleStyles.js
+++ b/app/styles/XLargeModuleStyles.js
@@ -1,13 +1,25 @@
-import { XLargeCoreStyles } from "@wrappid/core";
+// eslint-disable-next-line import/no-unresolved
+import { BaseStyle, IMPORTANT, XLargeUtilityStyles } from "@wrappid/styles";
 
-export default class XLargeModuleStyles extends XLargeCoreStyles {
+export default class XLargeModuleStyles extends BaseStyle {
+  xLargeUtilityStyles = new XLargeUtilityStyles().style;
   constructor() {
     super();
     this.style = {
       /**************************************************
        * Using XLargeUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.style.devBorder },
+      testWrappidStyleClass: { ...this.xLargeUtilityStyles.devBorder },
+      authBanner: {
+        backgroundImage: "url(./images/welcome-bg.png)" + IMPORTANT,
+        backgroundPosition: "center" + IMPORTANT,
+        backgroundRepeat: "no-repeat" + IMPORTANT,
+        backgroundSize: "cover" + IMPORTANT,
+        height: "100%" + IMPORTANT,
+      },
+      authContainer: { height: "100%" + IMPORTANT },
+      authForm: { height: "100%" + IMPORTANT },
+      authFormContainer: { width: "60%" + IMPORTANT },
     };
   }
 }

--- a/app/styles/XXLargeModuleStyles.js
+++ b/app/styles/XXLargeModuleStyles.js
@@ -1,13 +1,18 @@
-import { XXLargeCoreStyles } from "@wrappid/core";
 
-export default class XXLargeModuleStyles extends XXLargeCoreStyles {
+// --import { XX_LARGE_WINDOW_WIDTH } from "../config/constants";
+
+// eslint-disable-next-line import/no-unresolved
+import { BaseStyle, XXLargeUtilityStyles } from "@wrappid/styles";
+
+export default class XXLargeModuleStyles extends BaseStyle {
+  xxLargeUtilityStyles = new XXLargeUtilityStyles().style;
   constructor() {
     super();
     this.style = {
       /**************************************************
        * Using XXLargeUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.style.devBorder },
+      testWrappidStyleClass: { ...this.xxLargeUtilityStyles.devBorder },
     };
   }
 }


### PR DESCRIPTION
## Description
remove 'Auth' style object from CoreClasses.js and it will be shifted to ModuleClasses.js of auth-module

## Related Issues
Ref: #36